### PR TITLE
feat(column types): ability to use custom widgets as cells. Read-only

### DIFF
--- a/lib/pluto_grid.dart
+++ b/lib/pluto_grid.dart
@@ -81,6 +81,8 @@ part './src/ui/right_fixed_rows.dart';
 
 part './src/widget/cell_widget.dart';
 
+part './src/widget/cells/custom_cell_widget.dart';
+
 part './src/widget/cells/date_cell_widget.dart';
 
 part './src/widget/cells/default_cell_widget.dart';

--- a/lib/src/model/pluto_column.dart
+++ b/lib/src/model/pluto_column.dart
@@ -222,6 +222,12 @@ abstract class PlutoColumnType {
     );
   }
 
+  factory PlutoColumnType.widget(
+      {dynamic defaultValue,
+      @required Widget Function(dynamic value) widget}) {
+    return PlutoColumnTypeWidget(defaultValue: defaultValue, buildWidget: widget);
+  }
+
   bool isValid(dynamic value);
 
   int compare(dynamic a, dynamic b);
@@ -237,6 +243,8 @@ extension PlutoColumnTypeExtension on PlutoColumnType {
   bool get isDate => this is PlutoColumnTypeDate;
 
   bool get isTime => this is PlutoColumnTypeTime;
+
+  bool get isWidget => this is PlutoColumnTypeWidget;
 
   PlutoColumnTypeText get text {
     return this is PlutoColumnTypeText ? this : throw TypeError();
@@ -256,6 +264,10 @@ extension PlutoColumnTypeExtension on PlutoColumnType {
 
   PlutoColumnTypeTime get time {
     return this is PlutoColumnTypeTime ? this : throw TypeError();
+  }
+
+  PlutoColumnTypeWidget get widget {
+    return this is PlutoColumnTypeWidget ? this : throw TypeError();
   }
 
   bool get hasFormat => this is _PlutoColumnTypeHasFormat;
@@ -447,6 +459,26 @@ class PlutoColumnTypeTime implements PlutoColumnType {
   int compare(dynamic a, dynamic b) {
     return a.compareTo(b);
   }
+}
+
+class PlutoColumnTypeWidget implements PlutoColumnType {
+  @override
+  dynamic defaultValue;
+
+  final Widget Function(dynamic value) buildWidget;
+
+  @override
+  bool readOnly = true;
+
+  PlutoColumnTypeWidget({this.defaultValue, @required this.buildWidget});
+
+  @override
+  int compare(dynamic a, dynamic b) {
+    return a.compareTo(b);
+  }
+
+  @override
+  bool isValid(value) => true;
 }
 
 abstract class _PlutoColumnTypeHasFormat {

--- a/lib/src/widget/cell_widget.dart
+++ b/lib/src/widget/cell_widget.dart
@@ -182,12 +182,20 @@ class _CellWidgetState extends State<CellWidget>
 
   Widget _buildCell() {
     if (!_isCurrentCell || !_isEditing) {
-      return DefaultCellWidget(
-        stateManager: widget.stateManager,
-        cell: widget.cell,
-        column: widget.column,
-        rowIdx: widget.rowIdx,
-      );
+      if (widget.column.type.isWidget) {
+        return CustomCellWidget(
+          stateManager: widget.stateManager,
+          cell: widget.cell,
+          column: widget.column,
+        );
+      } else {
+        return DefaultCellWidget(
+          stateManager: widget.stateManager,
+          cell: widget.cell,
+          column: widget.column,
+          rowIdx: widget.rowIdx,
+        );
+      }
     }
 
     if (widget.column.type.isSelect) {
@@ -216,6 +224,12 @@ class _CellWidgetState extends State<CellWidget>
       );
     } else if (widget.column.type.isText) {
       return TextCellWidget(
+        stateManager: widget.stateManager,
+        cell: widget.cell,
+        column: widget.column,
+      );
+    } else if (widget.column.type.isWidget) {
+      return CustomCellWidget(
         stateManager: widget.stateManager,
         cell: widget.cell,
         column: widget.column,

--- a/lib/src/widget/cells/custom_cell_widget.dart
+++ b/lib/src/widget/cells/custom_cell_widget.dart
@@ -1,0 +1,35 @@
+part of '../../../pluto_grid.dart';
+
+class CustomCellWidget extends DefaultCellWidget implements _TextBaseMixinImpl {
+  final PlutoStateManager stateManager;
+  final PlutoCell cell;
+  final PlutoColumn column;
+
+  CustomCellWidget({
+    this.stateManager,
+    this.cell,
+    this.column,
+  });
+
+  @override
+  _CustomCellWidgetState createState() => _CustomCellWidgetState();
+}
+
+class _CustomCellWidgetState extends _DefaultCellWidgetState {
+
+  _CustomCellWidgetState();
+
+  Widget getCellWidget() {
+    if (widget.column.hasRenderer) {
+      return widget.column.renderer(PlutoColumnRendererContext(
+        column: widget.column,
+        rowIdx: widget.rowIdx,
+        row: thisRow,
+        cell: widget.cell,
+        stateManager: widget.stateManager,
+      ));
+    }
+    final type = widget.column.type as PlutoColumnTypeWidget;
+    return type.buildWidget(widget.cell.value);
+  }
+}


### PR DESCRIPTION
PlutoColumnTypeWidget provides ability to crete custom widget for column.
This widget should be read-only and all editing actions should be handled by
custom widget's code. "buildWidget" callback is required property, it stores
custom widget's build function.